### PR TITLE
Add navigation pages to dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import AuthPage from './pages/AuthPage';
 import Dashboard from './pages/Dashboard';
+import Wishlist from './pages/Wishlist';
+import KidsGift from './pages/KidsGift';
+import Event from './pages/Event';
 import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
@@ -8,11 +11,38 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<AuthPage />} />
-        <Route path="/dashboard" element={
-          <ProtectedRoute>
-            <Dashboard />
-          </ProtectedRoute>
-        } />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/wishlist"
+          element={
+            <ProtectedRoute>
+              <Wishlist />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/kids-gift"
+          element={
+            <ProtectedRoute>
+              <KidsGift />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/event"
+          element={
+            <ProtectedRoute>
+              <Event />
+            </ProtectedRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,37 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebase';
+
+export default function Sidebar() {
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await signOut(auth);
+    navigate('/');
+  };
+
+  return (
+    <div className="w-48 bg-gray-100 p-4 min-h-screen">
+      <nav className="flex flex-col space-y-2">
+        <Link to="/dashboard" className="px-3 py-2 rounded hover:bg-gray-200">
+          Dashboard
+        </Link>
+        <Link to="/wishlist" className="px-3 py-2 rounded hover:bg-gray-200">
+          Wishlist
+        </Link>
+        <Link to="/kids-gift" className="px-3 py-2 rounded hover:bg-gray-200">
+          Kids Gift
+        </Link>
+        <Link to="/event" className="px-3 py-2 rounded hover:bg-gray-200">
+          Event
+        </Link>
+      </nav>
+      <button
+        onClick={handleLogout}
+        className="mt-4 bg-red-500 text-white px-3 py-2 rounded"
+      >
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Event.jsx
+++ b/src/pages/Event.jsx
@@ -1,11 +1,11 @@
 import Sidebar from '../components/Sidebar';
 
-export default function Dashboard() {
+export default function Event() {
   return (
     <div className="flex">
       <Sidebar />
       <div className="p-6 flex-1">
-        <h1 className="text-2xl font-bold mb-4">Welcome to your Dashboard</h1>
+        <h1 className="text-2xl font-bold mb-4">Event Page</h1>
       </div>
     </div>
   );

--- a/src/pages/KidsGift.jsx
+++ b/src/pages/KidsGift.jsx
@@ -1,11 +1,11 @@
 import Sidebar from '../components/Sidebar';
 
-export default function Dashboard() {
+export default function KidsGift() {
   return (
     <div className="flex">
       <Sidebar />
       <div className="p-6 flex-1">
-        <h1 className="text-2xl font-bold mb-4">Welcome to your Dashboard</h1>
+        <h1 className="text-2xl font-bold mb-4">Kids Gift Page</h1>
       </div>
     </div>
   );

--- a/src/pages/Wishlist.jsx
+++ b/src/pages/Wishlist.jsx
@@ -1,11 +1,11 @@
 import Sidebar from '../components/Sidebar';
 
-export default function Dashboard() {
+export default function Wishlist() {
   return (
     <div className="flex">
       <Sidebar />
       <div className="p-6 flex-1">
-        <h1 className="text-2xl font-bold mb-4">Welcome to your Dashboard</h1>
+        <h1 className="text-2xl font-bold mb-4">Wishlist Page</h1>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a sidebar with navigation links
- create `Wishlist`, `KidsGift` and `Event` pages
- update Dashboard page to use the sidebar
- add protected routes for new pages

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3f79474833293f66a02cb3dd7de